### PR TITLE
Adding bats as a dependency

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -302,6 +302,16 @@ bandit:
     homebrew:
       packages: [bandit]
   ubuntu: [bandit]
+bats:
+  arch: [bats]
+  debian: [bats]
+  fedora: [bats]
+  gentoo: [dev-util/bats]
+  opensuse: [bats]
+  osx:
+    homebrew:
+      packages: [bats-core]
+  ubuntu: [bats]
 bazaar:
   arch: [breezy]
   debian: [bzr]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -307,10 +307,12 @@ bats:
   debian: [bats]
   fedora: [bats]
   gentoo: [dev-util/bats]
+  nixos: [bats]
   opensuse: [bats]
   osx:
     homebrew:
       packages: [bats-core]
+  rhel: [bats]
   ubuntu: [bats]
 bazaar:
   arch: [breezy]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

Bash Automated Testing System  (bats or bats-core)

## Package Upstream Source:

https://github.com/bats-core/bats-core?tab=readme-ov-file

## Purpose of using this:

Automated testing for bash scripts. Useful to validate any bash scripts that may be used instead of the standard python scripts. 

Distro packaging links:

## Links to Distribution Packages

https://bats-core.readthedocs.io/en/stable/installation.html

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=bats
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/bats
- Fedora: https://packages.fedoraproject.org/
  -https://src.fedoraproject.org/rpms/bats
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/bats/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-util/bats
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/bats-core
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/bats
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=24.05&show=bats&from=0&size=50&sort=relevance&type=packages&query=bats
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/bats
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/download/bats

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO bats

# The source is here:

https://github.com/bats-core/bats-core

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [x ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
